### PR TITLE
delay createP call in case sound file is large

### DIFF
--- a/scripts/06_KNNClassifier_with_sound_image.js
+++ b/scripts/06_KNNClassifier_with_sound_image.js
@@ -37,7 +37,6 @@ function setup() {
   video.hide();
 
   // Message Elements
-  msg = createP('Loading...');
   exampleA = createP('Examples Trained on A: 0');
   confidenceA = createP('Confidence for A: 0');;
   exampleB = createP('Examples Trained on B: 0');
@@ -81,6 +80,7 @@ function draw() {
 
 // A function to be called when the model has been loaded
 function modelLoaded() {
+  msg = createP('Loading...');
   msg.html('Model loaded!');
 }
 


### PR DESCRIPTION
when audio file is large, `modelLoaded()` can be executed before `setup()` and therefore `msg` will be `undefined`. As a quick fix I moved `createP` to `modelLoaded()`